### PR TITLE
Make transaction-category a many-to-one relationship

### DIFF
--- a/src-tauri/migrations/20251213055331_init.sql
+++ b/src-tauri/migrations/20251213055331_init.sql
@@ -25,16 +25,10 @@ CREATE TABLE IF NOT EXISTS "transaction" (
     amount REAL NOT NULL,
     date TEXT NOT NULL,
     account_id INTEGER NOT NULL,
-    FOREIGN KEY (account_id) REFERENCES account(id) ON DELETE CASCADE
+    category_id INTEGER,
+    FOREIGN KEY (account_id) REFERENCES account(id) ON DELETE CASCADE,
+    FOREIGN KEY (category_id) REFERENCES category(id) ON DELETE SET NULL
 );
 CREATE INDEX IF NOT EXISTS idx_transaction_date ON "transaction"(date);
 CREATE INDEX IF NOT EXISTS idx_transaction_account_id ON "transaction"(account_id);
-
-CREATE TABLE IF NOT EXISTS transaction_category (
-    transaction_id INTEGER NOT NULL,
-    category_id INTEGER NOT NULL,
-    PRIMARY KEY (transaction_id, category_id),
-    FOREIGN KEY (transaction_id) REFERENCES "transaction"(id) ON DELETE CASCADE,
-    FOREIGN KEY (category_id) REFERENCES category(id) ON DELETE CASCADE
-);
-CREATE INDEX IF NOT EXISTS idx_transaction_category_category_id ON transaction_category(category_id);
+CREATE INDEX IF NOT EXISTS idx_transaction_category_id ON "transaction"(category_id);


### PR DESCRIPTION
## Description
Transaction and category used to have a many-to-many relationship but that didn't make sense. This PR fixes it.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Doc update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] My code follows the style of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

