### PR TITLE
Add uncategorized category

### DIFF
--- a/src-tauri/migrations/20251213055331_init.sql
+++ b/src-tauri/migrations/20251213055331_init.sql
@@ -25,7 +25,7 @@ CREATE TABLE IF NOT EXISTS "transaction" (
     amount_cents INTEGER NOT NULL,
     date TEXT NOT NULL,
     account_id INTEGER NOT NULL,
-    category_id INTEGER,
+    category_id INTEGER NOT NULL,
     FOREIGN KEY (account_id) REFERENCES account(id) ON DELETE CASCADE,
     FOREIGN KEY (category_id) REFERENCES category(id) ON DELETE SET NULL
 );

--- a/src-tauri/migrations/20251224035610_seed_uncategorized_category.sql
+++ b/src-tauri/migrations/20251224035610_seed_uncategorized_category.sql
@@ -1,0 +1,1 @@
+INSERT INTO category (name, color) values ('Uncategorized', '#bbbbbb');

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -10,7 +10,7 @@ impl Database {
     pub async fn new(app_dir: &PathBuf) -> Result<Self, Box<dyn std::error::Error>> {
         fs::create_dir_all(&app_dir)?;
 
-        let db_path = app_dir.join("tally.db");
+        let db_path = app_dir.join("pennyful.db");
 
         println!("Initializing database at: {:?}", db_path);
 

--- a/src-tauri/src/fixtures/transactions.sql
+++ b/src-tauri/src/fixtures/transactions.sql
@@ -1,5 +1,3 @@
-INSERT INTO category (id, name, color) VALUES (1, "Category 1", "#FFFFFF");
-
 INSERT INTO bank (id, bank_name) VALUES
     (1, "Bank of America");
 

--- a/src-tauri/src/transactions/queries.rs
+++ b/src-tauri/src/transactions/queries.rs
@@ -27,7 +27,7 @@ mod tests {
                 Cents(dec!(-5.77)),
                 NaiveDate::from_ymd_opt(2025, 12, 15).unwrap(),
                 1,
-                Some(1)
+                1
             ),
             Transaction::new(
                 2,
@@ -35,7 +35,7 @@ mod tests {
                 Cents(dec!(-10.90)),
                 NaiveDate::from_ymd_opt(2025, 12, 16).unwrap(),
                 1,
-                Some(1)
+                1
             ),
             Transaction::new(
                 4,
@@ -43,7 +43,7 @@ mod tests {
                 Cents(dec!(-0.70)),
                 NaiveDate::from_ymd_opt(2025, 12, 16).unwrap(),
                 1,
-                Some(1)
+                1
             ),
             Transaction::new(
                 3,
@@ -51,7 +51,7 @@ mod tests {
                 Cents(dec!(-1.90)),
                 NaiveDate::from_ymd_opt(2025, 12, 17).unwrap(),
                 1,
-                Some(1)
+                1
             ),
         ]
     }

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -54,7 +54,7 @@ pub struct Transaction {
     pub amount: Cents,
     pub date: NaiveDate,
     account_id: u64,
-    category_id: Option<u64>,
+    category_id: u64,
 }
 
 impl Transaction {
@@ -66,7 +66,7 @@ impl Transaction {
         &self.account_id
     }
 
-    pub fn category_id(&self) -> &Option<u64> {
+    pub fn category_id(&self) -> &u64 {
         &self.category_id
     }
 
@@ -76,7 +76,7 @@ impl Transaction {
         amount: Cents,
         date: NaiveDate,
         account_id: u64,
-        category_id: Option<u64>
+        category_id: u64
     ) -> Self {
         Transaction {
             id, name, amount, date, account_id, category_id


### PR DESCRIPTION
## Description
We want to give transactions a default "Uncategorized" category instead of letting them have a NULLABLE `category_id` field. To accomplish this, we seed the DB with the "Uncategorized" categoryd.

Fixes #22 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Doc update

## How Has This Been Tested?

Passes all existing tests

## Checklist:

- [ ] My code follows the style of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

