### PR TITLE
Remember category decisions

### DIFF
--- a/src-tauri/migrations/20260802205322_add_transaction_category_rule.sql
+++ b/src-tauri/migrations/20260802205322_add_transaction_category_rule.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS transaction_category_rule (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL UNIQUE,
+    category_id INTEGER NOT NULL,
+    updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+    FOREIGN KEY (category_id) REFERENCES category(id) ON DELETE CASCADE
+);

--- a/src-tauri/src/plaid/commands.rs
+++ b/src-tauri/src/plaid/commands.rs
@@ -98,8 +98,6 @@ pub async fn sync_transactions(
         .await
         .map_err(|e| format!("Error fetching uncategorized category: {e}"))?;
 
-    // Saved merchant-name -> category rules so newly added transactions inherit the
-    // category the user previously chose for that merchant.
     let rules = transactions::queries::get_category_rules(&db.0)
         .await
         .map_err(|e| format!("Error fetching category rules: {e}"))?;
@@ -111,7 +109,7 @@ pub async fn sync_transactions(
             .await
             .map_err(|e| format!("Failed to begin transaction: {e}"))?;
 
-    let skipped_duplicates = transactions::queries::add_plaid_transactions(&mut tx, added, uncategorized.id(), &rules)
+    let skipped_duplicates = transactions::queries::add_plaid_transactions(&mut tx, added, *uncategorized.id(), &rules)
         .await
         .map_err(|e| format!("Failed to add plaid transactions: {e}"))?;
     println!(

--- a/src-tauri/src/plaid/commands.rs
+++ b/src-tauri/src/plaid/commands.rs
@@ -98,6 +98,12 @@ pub async fn sync_transactions(
         .await
         .map_err(|e| format!("Error fetching uncategorized category: {e}"))?;
 
+    // Saved merchant-name -> category rules so newly added transactions inherit the
+    // category the user previously chose for that merchant.
+    let rules = transactions::queries::get_category_rules(&db.0)
+        .await
+        .map_err(|e| format!("Error fetching category rules: {e}"))?;
+
     // Apply all writes (and the cursor advance) in one transaction so a partial
     // failure rolls back and the sync cleanly re-runs from the same cursor.
     let mut tx =
@@ -105,7 +111,7 @@ pub async fn sync_transactions(
             .await
             .map_err(|e| format!("Failed to begin transaction: {e}"))?;
 
-    let skipped_duplicates = transactions::queries::add_plaid_transactions(&mut tx, added, uncategorized.id())
+    let skipped_duplicates = transactions::queries::add_plaid_transactions(&mut tx, added, uncategorized.id(), &rules)
         .await
         .map_err(|e| format!("Failed to add plaid transactions: {e}"))?;
     println!(

--- a/src-tauri/src/transactions/commands.rs
+++ b/src-tauri/src/transactions/commands.rs
@@ -1,5 +1,5 @@
 use crate::types::{SortDir, TransactionWithAccount};
-use crate::{AppState, transactions};
+use crate::{AppState, categories, transactions};
 
 #[derive(serde::Serialize)]
 pub struct PaginatedSortedTransactionsResponse {
@@ -51,9 +51,18 @@ pub async fn update_transaction_category(
     transaction_id: i64,
     category_id: i64,
 ) -> Result<(), String> {
-    transactions::queries::update_transaction_category(&state.db.0, transaction_id, category_id)
+    let uncategorized = categories::queries::get_uncategorized_category(&state.db.0)
         .await
-        .map_err(|e| format!("Error updating transaction category: {e}"))
+        .map_err(|e| format!("Error fetching uncategorized category: {e}"))?;
+
+    transactions::queries::update_transaction_category(
+        &state.db.0,
+        transaction_id,
+        category_id,
+        *uncategorized.id(),
+    )
+    .await
+    .map_err(|e| format!("Error updating transaction category: {e}"))
 }
 
 #[tauri::command]

--- a/src-tauri/src/transactions/queries.rs
+++ b/src-tauri/src/transactions/queries.rs
@@ -2,6 +2,7 @@ use crate::{plaid::types::PlaidTransaction, types::SortDir};
 use crate::types::{Transaction, TransactionWithAccount};
 use ::plaid::model::RemovedTransaction;
 use sqlx::{Pool, QueryBuilder, Sqlite, SqliteConnection};
+use std::collections::HashMap;
 
 pub async fn get_transactions(
     pool: &Pool<Sqlite>,
@@ -131,6 +132,7 @@ pub async fn add_plaid_transactions(
     conn: &mut SqliteConnection,
     new_transactions: Vec<PlaidTransaction>,
     default_category: &i64,
+    rules: &HashMap<String, i64>,
 ) -> Result<u64, sqlx::Error> {
     if new_transactions.is_empty() {
         return Ok(0);
@@ -144,6 +146,15 @@ pub async fn add_plaid_transactions(
     query_builder.push_values(new_transactions, |mut b, t| {
         let account_id = *t.account_id();
 
+        // A saved rule for this merchant name overrides the default (Uncategorized)
+        // category, so future transactions inherit the user's earlier decision.
+        let category_id = t
+            .name
+            .as_deref()
+            .and_then(|name| rules.get(name))
+            .copied()
+            .unwrap_or(*default_category);
+
         b.push_bind(t.plaid_transaction_id)
             .push_bind(t.name.unwrap_or("".to_string()))
             .push_bind(t.merchant_entity_id)
@@ -151,7 +162,7 @@ pub async fn add_plaid_transactions(
             .push_bind(t.date)
             .push_bind(t.pending)
             .push_bind(account_id)
-            .push_bind(default_category);
+            .push_bind(category_id);
     });
     query_builder.push(
         " ON CONFLICT(plaid_transaction_id) WHERE plaid_transaction_id IS NOT NULL DO NOTHING",
@@ -167,11 +178,82 @@ pub async fn update_transaction_category(
     pool: &Pool<Sqlite>,
     transaction_id: i64,
     category_id: i64,
+    uncategorized_id: i64,
 ) -> Result<(), sqlx::Error> {
+    let mut tx = pool.begin().await?;
+
     sqlx::query(r#"UPDATE 'transaction' SET category_id=? WHERE id=?"#)
         .bind(category_id)
         .bind(transaction_id)
-        .execute(pool)
+        .execute(&mut *tx)
+        .await?;
+
+    // Remember this decision so future transactions from the same merchant inherit
+    // the category. Setting a transaction back to Uncategorized clears the rule.
+    let name: Option<String> =
+        sqlx::query_scalar(r#"SELECT name FROM 'transaction' WHERE id=?"#)
+            .bind(transaction_id)
+            .fetch_optional(&mut *tx)
+            .await?;
+
+    if let Some(name) = name {
+        // Skip blank names so we never create a "" rule that would clobber every
+        // unnamed transaction on the next sync.
+        if !name.is_empty() {
+            if category_id == uncategorized_id {
+                delete_category_rule(&mut tx, &name).await?;
+            } else {
+                upsert_category_rule(&mut tx, &name, category_id).await?;
+            }
+        }
+    }
+
+    tx.commit().await?;
+
+    Ok(())
+}
+
+/// Loads every saved merchant-name -> category rule as a lookup map.
+pub async fn get_category_rules(
+    pool: &Pool<Sqlite>,
+) -> Result<HashMap<String, i64>, sqlx::Error> {
+    let rules: Vec<(String, i64)> =
+        sqlx::query_as(r#"SELECT name, category_id FROM transaction_category_rule"#)
+            .fetch_all(pool)
+            .await?;
+
+    Ok(rules.into_iter().collect())
+}
+
+async fn upsert_category_rule(
+    conn: &mut SqliteConnection,
+    name: &str,
+    category_id: i64,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        r#"
+        INSERT INTO transaction_category_rule (name, category_id)
+        VALUES (?, ?)
+        ON CONFLICT(name) DO UPDATE SET
+            category_id=excluded.category_id,
+            updated_at=datetime('now')
+        "#,
+    )
+    .bind(name)
+    .bind(category_id)
+    .execute(&mut *conn)
+    .await?;
+
+    Ok(())
+}
+
+async fn delete_category_rule(
+    conn: &mut SqliteConnection,
+    name: &str,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(r#"DELETE FROM transaction_category_rule WHERE name=?"#)
+        .bind(name)
+        .execute(&mut *conn)
         .await?;
 
     Ok(())
@@ -320,7 +402,8 @@ mod tests {
                 plaid_txn("txn-1", "Coffee", -4.50, false),
                 plaid_txn("txn-2", "Books", -20.00, false),
             ],
-            &1
+            &1,
+            &HashMap::new(),
         )
         .await?;
         assert_eq!(skipped, 0);
@@ -348,9 +431,13 @@ mod tests {
         pool: Pool<Sqlite>,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let mut conn = pool.acquire().await?;
-        let first =
-            add_plaid_transactions(&mut conn, vec![plaid_txn("txn-1", "Coffee", -4.50, false)], &1)
-                .await?;
+        let first = add_plaid_transactions(
+            &mut conn,
+            vec![plaid_txn("txn-1", "Coffee", -4.50, false)],
+            &1,
+            &HashMap::new(),
+        )
+        .await?;
         assert_eq!(first, 0);
 
         // Re-syncing the same transaction (Plaid resends) must not duplicate it, and
@@ -358,7 +445,8 @@ mod tests {
         let second = add_plaid_transactions(
             &mut conn,
             vec![plaid_txn("txn-1", "Coffee CHANGED", -9.99, false)],
-            &1
+            &1,
+            &HashMap::new(),
         )
         .await?;
         assert_eq!(second, 1);
@@ -388,7 +476,8 @@ mod tests {
         add_plaid_transactions(
             &mut conn,
             vec![plaid_txn("txn-1", "Pending Coffee", -4.50, true)],
-            &1
+            &1,
+            &HashMap::new(),
         )
         .await?;
 
@@ -413,7 +502,13 @@ mod tests {
         pool: Pool<Sqlite>,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let mut conn = pool.acquire().await?;
-        add_plaid_transactions(&mut conn, vec![plaid_txn("txn-1", "Coffee", -4.50, false)], &1).await?;
+        add_plaid_transactions(
+            &mut conn,
+            vec![plaid_txn("txn-1", "Coffee", -4.50, false)],
+            &1,
+            &HashMap::new(),
+        )
+        .await?;
 
         remove_plaid_transactions(
             &mut conn,
@@ -539,11 +634,11 @@ mod tests {
     async fn update_reassigns_and_overwrites_category(
         pool: Pool<Sqlite>,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        update_transaction_category(&pool, 1, 4).await?;
+        update_transaction_category(&pool, 1, 4, 1).await?;
         assert_eq!(category_of(&all_transactions(&pool).await?, 1), "Groceries");
 
         // A subsequent update replaces the previous category (last write wins).
-        update_transaction_category(&pool, 1, 2).await?;
+        update_transaction_category(&pool, 1, 2, 1).await?;
         assert_eq!(category_of(&all_transactions(&pool).await?, 1), "Income");
         Ok(())
     }
@@ -552,7 +647,7 @@ mod tests {
     async fn update_only_affects_target_transaction(
         pool: Pool<Sqlite>,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        update_transaction_category(&pool, 1, 4).await?;
+        update_transaction_category(&pool, 1, 4, 1).await?;
 
         let transactions = all_transactions(&pool).await?;
         assert_eq!(category_of(&transactions, 1), "Groceries");
@@ -572,7 +667,7 @@ mod tests {
     ) -> Result<(), Box<dyn std::error::Error>> {
         // category_id 999 has no matching category row; the foreign key on
         // transaction.category_id should reject the update.
-        let result = update_transaction_category(&pool, 1, 999).await;
+        let result = update_transaction_category(&pool, 1, 999, 1).await;
         assert!(
             result.is_err(),
             "updating to a non-existent category should fail"
@@ -580,6 +675,84 @@ mod tests {
 
         // The rejected update must leave the transaction's category unchanged.
         assert_eq!(category_of(&all_transactions(&pool).await?, 1), "Uncategorized");
+        Ok(())
+    }
+
+    async fn rule_for(pool: &Pool<Sqlite>, name: &str) -> Option<i64> {
+        sqlx::query_scalar("SELECT category_id FROM transaction_category_rule WHERE name = ?")
+            .bind(name)
+            .fetch_optional(pool)
+            .await
+            .expect("query rule")
+    }
+
+    #[sqlx::test(fixtures(path = "../fixtures", scripts("transactions")))]
+    async fn update_records_and_replaces_merchant_rule(
+        pool: Pool<Sqlite>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        // Transaction 1's name is "TRANSACTION 1" (see get_expected_transactions).
+        update_transaction_category(&pool, 1, 4, 1).await?;
+        assert_eq!(rule_for(&pool, "TRANSACTION 1").await, Some(4));
+
+        // Re-categorizing the same merchant overwrites the rule (still one row).
+        update_transaction_category(&pool, 1, 2, 1).await?;
+        assert_eq!(rule_for(&pool, "TRANSACTION 1").await, Some(2));
+        let count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM transaction_category_rule WHERE name = ?")
+                .bind("TRANSACTION 1")
+                .fetch_one(&pool)
+                .await?;
+        assert_eq!(count, 1);
+        Ok(())
+    }
+
+    #[sqlx::test(fixtures(path = "../fixtures", scripts("transactions")))]
+    async fn update_to_uncategorized_clears_merchant_rule(
+        pool: Pool<Sqlite>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        update_transaction_category(&pool, 1, 4, 1).await?;
+        assert_eq!(rule_for(&pool, "TRANSACTION 1").await, Some(4));
+
+        // Setting it back to Uncategorized (id 1) removes the remembered rule.
+        update_transaction_category(&pool, 1, 1, 1).await?;
+        assert_eq!(rule_for(&pool, "TRANSACTION 1").await, None);
+        Ok(())
+    }
+
+    #[sqlx::test(fixtures(path = "../fixtures", scripts("plaid_sync")))]
+    async fn add_applies_saved_merchant_rule(
+        pool: Pool<Sqlite>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        // A saved rule maps "Coffee" -> Groceries (category 4).
+        sqlx::query("INSERT INTO transaction_category_rule (name, category_id) VALUES ('Coffee', 4)")
+            .execute(&pool)
+            .await?;
+        let rules = get_category_rules(&pool).await?;
+
+        let mut conn = pool.acquire().await?;
+        add_plaid_transactions(
+            &mut conn,
+            vec![
+                plaid_txn("txn-known", "Coffee", -4.50, false),
+                plaid_txn("txn-unknown", "Mystery Shop", -20.00, false),
+            ],
+            &1,
+            &rules,
+        )
+        .await?;
+
+        let category_sql = "SELECT category_id FROM 'transaction' WHERE plaid_transaction_id = ?";
+        let known: i64 = sqlx::query_scalar(category_sql)
+            .bind("txn-known")
+            .fetch_one(&pool)
+            .await?;
+        let unknown: i64 = sqlx::query_scalar(category_sql)
+            .bind("txn-unknown")
+            .fetch_one(&pool)
+            .await?;
+
+        assert_eq!(known, 4, "rule merchant inherits saved category");
+        assert_eq!(unknown, 1, "unknown merchant falls back to default");
         Ok(())
     }
 }

--- a/src-tauri/src/transactions/queries.rs
+++ b/src-tauri/src/transactions/queries.rs
@@ -131,7 +131,7 @@ pub async fn get_paginated_sorted_transactions(
 pub async fn add_plaid_transactions(
     conn: &mut SqliteConnection,
     new_transactions: Vec<PlaidTransaction>,
-    default_category: &i64,
+    default_category: i64,
     rules: &HashMap<String, i64>,
 ) -> Result<u64, sqlx::Error> {
     if new_transactions.is_empty() {
@@ -146,14 +146,12 @@ pub async fn add_plaid_transactions(
     query_builder.push_values(new_transactions, |mut b, t| {
         let account_id = *t.account_id();
 
-        // A saved rule for this merchant name overrides the default (Uncategorized)
-        // category, so future transactions inherit the user's earlier decision.
         let category_id = t
             .name
             .as_deref()
             .and_then(|name| rules.get(name))
             .copied()
-            .unwrap_or(*default_category);
+            .unwrap_or(default_category);
 
         b.push_bind(t.plaid_transaction_id)
             .push_bind(t.name.unwrap_or("".to_string()))
@@ -182,14 +180,13 @@ pub async fn update_transaction_category(
 ) -> Result<(), sqlx::Error> {
     let mut tx = pool.begin().await?;
 
-    sqlx::query(r#"UPDATE 'transaction' SET category_id=? WHERE id=?"#)
+    let res = sqlx::query(r#"UPDATE 'transaction' SET category_id=? WHERE id=?"#)
         .bind(category_id)
         .bind(transaction_id)
         .execute(&mut *tx)
         .await?;
 
     // Remember this decision so future transactions from the same merchant inherit
-    // the category. Setting a transaction back to Uncategorized clears the rule.
     let name: Option<String> =
         sqlx::query_scalar(r#"SELECT name FROM 'transaction' WHERE id=?"#)
             .bind(transaction_id)
@@ -197,8 +194,6 @@ pub async fn update_transaction_category(
             .await?;
 
     if let Some(name) = name {
-        // Skip blank names so we never create a "" rule that would clobber every
-        // unnamed transaction on the next sync.
         if !name.is_empty() {
             if category_id == uncategorized_id {
                 delete_category_rule(&mut tx, &name).await?;
@@ -213,7 +208,6 @@ pub async fn update_transaction_category(
     Ok(())
 }
 
-/// Loads every saved merchant-name -> category rule as a lookup map.
 pub async fn get_category_rules(
     pool: &Pool<Sqlite>,
 ) -> Result<HashMap<String, i64>, sqlx::Error> {
@@ -402,7 +396,7 @@ mod tests {
                 plaid_txn("txn-1", "Coffee", -4.50, false),
                 plaid_txn("txn-2", "Books", -20.00, false),
             ],
-            &1,
+            1,
             &HashMap::new(),
         )
         .await?;
@@ -434,7 +428,7 @@ mod tests {
         let first = add_plaid_transactions(
             &mut conn,
             vec![plaid_txn("txn-1", "Coffee", -4.50, false)],
-            &1,
+            1,
             &HashMap::new(),
         )
         .await?;
@@ -445,7 +439,7 @@ mod tests {
         let second = add_plaid_transactions(
             &mut conn,
             vec![plaid_txn("txn-1", "Coffee CHANGED", -9.99, false)],
-            &1,
+            1,
             &HashMap::new(),
         )
         .await?;
@@ -476,7 +470,7 @@ mod tests {
         add_plaid_transactions(
             &mut conn,
             vec![plaid_txn("txn-1", "Pending Coffee", -4.50, true)],
-            &1,
+            1,
             &HashMap::new(),
         )
         .await?;
@@ -505,7 +499,7 @@ mod tests {
         add_plaid_transactions(
             &mut conn,
             vec![plaid_txn("txn-1", "Coffee", -4.50, false)],
-            &1,
+            1,
             &HashMap::new(),
         )
         .await?;
@@ -690,11 +684,9 @@ mod tests {
     async fn update_records_and_replaces_merchant_rule(
         pool: Pool<Sqlite>,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        // Transaction 1's name is "TRANSACTION 1" (see get_expected_transactions).
         update_transaction_category(&pool, 1, 4, 1).await?;
         assert_eq!(rule_for(&pool, "TRANSACTION 1").await, Some(4));
 
-        // Re-categorizing the same merchant overwrites the rule (still one row).
         update_transaction_category(&pool, 1, 2, 1).await?;
         assert_eq!(rule_for(&pool, "TRANSACTION 1").await, Some(2));
         let count: i64 =
@@ -713,7 +705,6 @@ mod tests {
         update_transaction_category(&pool, 1, 4, 1).await?;
         assert_eq!(rule_for(&pool, "TRANSACTION 1").await, Some(4));
 
-        // Setting it back to Uncategorized (id 1) removes the remembered rule.
         update_transaction_category(&pool, 1, 1, 1).await?;
         assert_eq!(rule_for(&pool, "TRANSACTION 1").await, None);
         Ok(())
@@ -736,7 +727,7 @@ mod tests {
                 plaid_txn("txn-known", "Coffee", -4.50, false),
                 plaid_txn("txn-unknown", "Mystery Shop", -20.00, false),
             ],
-            &1,
+            1,
             &rules,
         )
         .await?;


### PR DESCRIPTION
When a transaction is categorized, the user's choice will be remembered for all future transactions so that they can avoid repeated work.